### PR TITLE
Removing 'page name with different URI encoding'

### DIFF
--- a/apps/source control test/folder name with different URI encoding/page name with different URI encoding/.positions.json
+++ b/apps/source control test/folder name with different URI encoding/page name with different URI encoding/.positions.json
@@ -1,8 +1,0 @@
-{
-  "button1": {
-    "row": 4.8,
-    "col": 3,
-    "height": 1,
-    "width": 2
-  }
-}

--- a/apps/source control test/folder name with different URI encoding/page name with different URI encoding/main.rsx
+++ b/apps/source control test/folder name with different URI encoding/page name with different URI encoding/main.rsx
@@ -1,3 +1,0 @@
-<App>
-  <Button id="button1" text="Button" />
-</App>

--- a/apps/source control test/folder name with different URI encoding/page name with different URI encoding/metadata.json
+++ b/apps/source control test/folder name with different URI encoding/page name with different URI encoding/metadata.json
@@ -1,9 +1,0 @@
-{
-  "toolscriptVersion": "1.0.0",
-  "version": "43.0.9",
-  "pageUuid": "de5e240c-331e-11ef-aa10-4b0d95238382",
-  "appTemplate": {
-    "version": "3.50.0",
-    "experimentalDataTabEnabled": true
-  }
-}


### PR DESCRIPTION
### Removing 'page name with different URI encoding'

This PR will remove the application from the Retool Source Control repository.

Preview application here: https://subfolder.retool.dev/apps/source%20control%20test/folder%20name%20with%20different%20URI%20encoding/page%20name%20with%20different%20URI%20encoding
